### PR TITLE
Basic port to Bash of the environment setup and workspace creation scripts.

### DIFF
--- a/oasp4j-ide-scripts/pom.xml
+++ b/oasp4j-ide-scripts/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  
+
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.oasp.java.dev</groupId>
@@ -41,6 +41,9 @@
               <goal>resources</goal>
             </goals>
             <configuration>
+              <nonFilteredFileExtensions>
+                <nonFilteredFileExtension>reg</nonFilteredFileExtension>
+              </nonFilteredFileExtensions>
               <includeEmptyDirs>true</includeEmptyDirs>
             </configuration>
           </execution>
@@ -87,7 +90,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/oasp4j-ide-scripts/src/main/resources/create-or-update-workspace.sh
+++ b/oasp4j-ide-scripts/src/main/resources/create-or-update-workspace.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+# pushd .
+
+if [ -n $1 ]; then
+    OASP_WORKSPACE=$1
+fi
+
+. scripts/environment-project.sh
+
+if [ ! -d $OASP_SOFTWARE_PATH ]; then
+    echo "Could not find folder $OASP_SOFTWARE_PATH"
+    echo "If you want to change its name see the variables.bat"
+    echo "Execution aborted"
+    exit 1
+fi
+if [ ! -d $OASP_WORKSPACES_PATH ]; then
+    echo "Could not find folder $OASP_WORKSPACES_PATH"
+    echo "If you want to change its name see the variables.bat"
+    echo "Execution aborted"
+    exit 1
+fi
+if [ ! -d $OASP_WORKSPACE_PATH ]; then
+    echo "Could not find workspace $OASP_WORKSPACE_PATH"
+    echo "Execution aborted"
+    exit 1
+fi
+if [ ! -d $OASP_SETTINGS_PATH ]; then
+    echo "Could not find folder $OASP_SETTINGS_PATH"
+    echo "If you want to change its name see the variables.bat"
+    echo "Execution aborted"
+    exit 1
+fi
+
+
+if [ ! -e $OASP_CONF_PATH/.m2 ]; then
+    mkdir $OASP_CONF_PATH/.m2
+fi
+if [ ! -e $OASP_CONF_PATH/.m2/settings.xml ]; then
+    cp $OASP_SETTINGS_PATH/maven/settings.xml $OASP_CONF_PATH/.m2/settings.xml
+    echo "Copied $OASP_SETTINGS_PATH/maven/settings.xml to $OASP_CONF_PATH/.m2/settings.xml"
+fi
+
+# TODO: Port subversion config
+
+
+if [ ! -d $OASP_ECLIPSE_TEMPLATES_PATH ]; then
+    echo "Could not find folder $OASP_ECLIPSE_TEMPLATES_PATH"
+    echo "Execution aborted"
+    exit 1
+fi
+if [ ! -e $OASP_ECLIPSE_REPLACEMENT_PATTERNS_PATH ]; then
+    echo "Could not find file $OASP_ECLIPSE_REPLACEMENT_PATTERNS_PATH"
+    echo "Execution aborted"
+    exit 1
+fi
+
+# copys/merges the *.prefs form $OASP_SETTINGS_PATH/eclipse/workspace\... to specified Eclipse workspace
+# In order to run this jar requires the following environment variables:
+# WORKSPACE_PATH, ECLIPSE_TEMPLATES_PATH and REPLACEMENT_PATTERNS_PATH
+echo $OASP_WORKSPACE_REL_PATH
+echo $OASP_ECLIPSE_TEMPLATES_REL_PATH
+WORKSPACE_PATH=$OASP_WORKSPACE_REL_PATH \
+  ECLIPSE_TEMPLATES_PATH=$OASP_WORKSPACE_REL_PATH/$OASP_SETTINGS_REL_PATH/$OASP_ECLIPSE_TEMPLATES_REL_PATH \
+  REPLACEMENT_PATTERNS_PATH=$OASP_ECLIPSE_REPLACEMENT_PATTERNS_PATH \
+  java -jar $OASP_SCRIPTS_PATH/$OASP4J_ECLIPSE_CONFIGURATOR -u
+echo "Eclipse preferences for workspace: $OASP_WORKSPACE have been created/updated"
+
+
+# popd

--- a/oasp4j-ide-scripts/src/main/resources/create-or-update-workspace.sh
+++ b/oasp4j-ide-scripts/src/main/resources/create-or-update-workspace.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# pushd .
+pushd $OASP_PROJECT_HOME > /dev/null
 
 if [ -n $1 ]; then
     OASP_WORKSPACE=$1
@@ -68,4 +68,4 @@ WORKSPACE_PATH=$OASP_WORKSPACE_REL_PATH \
 echo "Eclipse preferences for workspace: $OASP_WORKSPACE have been created/updated"
 
 
-# popd
+popd > /dev/null

--- a/oasp4j-ide-scripts/src/main/resources/env.sh
+++ b/oasp4j-ide-scripts/src/main/resources/env.sh
@@ -1,3 +1,12 @@
-export OASP_PROJECT_HOME=`pwd -P`
+#!/bin/bash
+#
+# Source this script from a BASH shell to setup the shell for the corresponding project.
+# 
+set -e
 
-. scripts/environment-project.sh
+export OASP_PROJECT_HOME=`pwd -P`/`dirname $BASH_SOURCE`
+pushd $OASP_PROJECT_HOME > /dev/null
+
+. $OASP_PROJECT_HOME/scripts/environment-project.sh
+
+popd > /dev/null

--- a/oasp4j-ide-scripts/src/main/resources/env.sh
+++ b/oasp4j-ide-scripts/src/main/resources/env.sh
@@ -1,0 +1,3 @@
+export OASP_PROJECT_HOME=`pwd -P`
+
+. scripts/environment-project.sh

--- a/oasp4j-ide-scripts/src/main/resources/scripts/environment-project.sh
+++ b/oasp4j-ide-scripts/src/main/resources/scripts/environment-project.sh
@@ -1,0 +1,46 @@
+. $OASP_PROJECT_HOME/variables.sh
+if [ -f $OASP_PROJECT_HOME/variables-customized.sh ]; then
+    . $OASP_PROJECT_HOME/variables-customized.sh
+fi
+
+if [ -z $OASP_WORKSPACE ]; then
+    export OASP_WORKSPACE=$OASP_MAIN_BRANCH
+fi
+export OASP_WORKSPACE_REL_PATH=workspaces/$OASP_WORKSPACE
+export OASP_WORKSPACE_PATH=$OASP_WORKSPACES_PATH/$OASP_WORKSPACE
+
+export OASP_WORKSPACE_PLUGINS_PATH=$OASP_WORKSPACE_PATH/.metadata/.plugins
+export OASP_SETTINGS_PATH=$OASP_WORKSPACE_PATH/$OASP_SETTINGS_REL_PATH
+export OASP_ECLIPSE_TEMPLATES_PATH=$OASP_WORKSPACE_REL_PATH/$OASP_SETTINGS_REL_PATH/$OASP_ECLIPSE_TEMPLATES_REL_PATH
+
+if [ -f $OASP_SETTINGS_PATH/ide-properties.sh ]; then
+    . $OASP_SETTINGS_PATH/ide-properties.sh
+fi
+
+export OASP4J_IDE_VERSION=1.3.1
+export OASP4J_ECLIPSE_CONFIGURATOR=oasp4j-ide-eclipse-configurator-1.3.1.jar
+
+###
+# JAVA
+# TODO: Port this
+###
+
+###
+# MAVEN
+###
+export M2_HOME=$OASP_SOFTWARE_PATH/maven
+export M2_CONF=$OASP_CONF_PATH/.m2/settings.xml
+export MAVEN_OPTS="-Xmx512m -Duser.home=$OASP_CONF_PATH"
+export MAVEN_HOME=$M2_HOME
+export PATH=$M2_HOME/bin:$PATH
+
+###
+# Eclipse
+# TODO: Port this
+###
+
+###
+# NodeJS
+# TODO: Port this
+###
+

--- a/oasp4j-ide-scripts/src/main/resources/variables.sh
+++ b/oasp4j-ide-scripts/src/main/resources/variables.sh
@@ -1,0 +1,18 @@
+#********************************************************************************
+# These environment variables may be customized by the user.
+# To do so, create a file with the name variables-customized.bat
+# and perform your changes there so they do not get lost if you update. 
+# Whenever variables-customized.bat is present it will override the property values defined here.
+#********************************************************************************
+
+export OASP_MAIN_BRANCH=main
+
+export OASP_SCRIPTS_PATH=$OASP_PROJECT_HOME/scripts
+export OASP_CONF_PATH=$OASP_PROJECT_HOME/conf
+export OASP_WORKSPACES_PATH=$OASP_PROJECT_HOME/workspaces
+export OASP_SETTINGS_REL_PATH=development/settings
+export OASP_ECLIPSE_TEMPLATES_REL_PATH=eclipse/workspace
+export OASP_SOFTWARE_PATH=$OASP_PROJECT_HOME/software
+
+export M2_REPO=$OASP_CONF_PATH/.m2/repository
+


### PR DESCRIPTION
Right now, it only setups Maven and the necessary variables to get the eclipse config generator running.

I am following the same structure, more or less, than the windows version, so future changes are more portable between the two.

Instead of a console.bat there is a env.sh, which one should source from a bash prompt to set up the necessary variables