### PR TITLE
Java and Mvn setup in Linux port and small bug fix

### DIFF
--- a/oasp4j-ide-scripts/src/main/resources/env.sh
+++ b/oasp4j-ide-scripts/src/main/resources/env.sh
@@ -3,8 +3,8 @@
 # Source this script from a BASH shell to setup the shell for the corresponding project.
 # 
 
-export OASP_PROJECT_HOME=`pwd -P`/`dirname $BASH_SOURCE`
-pushd $OASP_PROJECT_HOME > /dev/null
+pushd "$(dirname "$BASH_SOURCE")" >/dev/null
+export OASP_PROJECT_HOME=`pwd`
 
 . $OASP_PROJECT_HOME/scripts/environment-project
 

--- a/oasp4j-ide-scripts/src/main/resources/env.sh
+++ b/oasp4j-ide-scripts/src/main/resources/env.sh
@@ -2,11 +2,10 @@
 #
 # Source this script from a BASH shell to setup the shell for the corresponding project.
 # 
-set -e
 
 export OASP_PROJECT_HOME=`pwd -P`/`dirname $BASH_SOURCE`
 pushd $OASP_PROJECT_HOME > /dev/null
 
-. $OASP_PROJECT_HOME/scripts/environment-project.sh
+. $OASP_PROJECT_HOME/scripts/environment-project
 
 popd > /dev/null

--- a/oasp4j-ide-scripts/src/main/resources/scripts/environment-project
+++ b/oasp4j-ide-scripts/src/main/resources/scripts/environment-project
@@ -27,8 +27,10 @@ export ECLIPSE_CONFIGURATOR=oasp4j-ide-eclipse-configurator-${eclipse-configurat
 
 ###
 # JAVA
-# TODO: Port this
 ###
+export JAVA_HOME=$SOFTWARE_PATH/java
+# export JAVA_OPTS=-Dhttp.proxyHost=myproxy.com -Dhttp.proxyPort=8080
+export PATH=$JAVA_HOME/bin:$PATH
 
 ###
 # MAVEN
@@ -47,6 +49,10 @@ export ECLIPSE=$ECLIPSE_HOME/eclipse
 
 ###
 # NodeJS
-# TODO: Port this
 ###
+if [ -d "$SOFTWARE_PATH/nodejs" ]; then
+  export PATH=$SOFTWARE_PATH/nodejs/bin:$PATH
+fi
 
+
+echo "IDE environment has been initialized."


### PR DESCRIPTION
The script will now setup environment variables for a JDK in software/java, and optionally for nodejs.

I also fixed a small error which was left over after removing the ".sh" extensions.