### PR TITLE
support JAVA_HOME with spaces for Eclipse start batches

### DIFF
--- a/oasp4j-ide-scripts/src/main/resources/scripts/environment-project.bat
+++ b/oasp4j-ide-scripts/src/main/resources/scripts/environment-project.bat
@@ -39,7 +39,7 @@ set MAVEN_HOME=%M2_HOME%
 rem ********************************************************************************
 rem Eclipse
 set ECLIPSE_HOME=%SOFTWARE_PATH%\eclipse
-set ECLIPSE_OPT=-vm %JAVA_HOME%\bin\javaw -showlocation %WORKSPACE% -vmargs %ECLIPSE_VMARGS%
+set ECLIPSE_OPT=-vm "%JAVA_HOME%\bin\javaw" -showlocation %WORKSPACE% -vmargs %ECLIPSE_VMARGS%
 
 rem ********************************************************************************
 rem Path


### PR DESCRIPTION
in case someone does not want to use the java from the software package
they will likely want to use their system installation in Program Files
which will most likely have a space in its path

(this change is useful for Windows users only)