### PR TITLE
Changes for adding external maven in eclipse by default

### DIFF
--- a/oasp4j-ide-settings/src/main/settings/eclipse/workspace/update/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.m2e.core.prefs
+++ b/oasp4j-ide-settings/src/main/settings/eclipse/workspace/update/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.m2e.core.prefs
@@ -6,3 +6,7 @@ eclipse.m2.updateIndexes=false
 eclipse.m2.userSettingsFile=${client.env.home}/conf/.m2/settings.xml
 eclipse.m2.WorkspacelifecycleMappingsLocation=${client.env.home}/${SETTINGS_PATH}/eclipse/lifecycle-mapping-metadata.xml
 eclipse.preferences.version=1
+eclipse.m2.runtimes=maven
+eclipse.m2.runtimesNodes/maven/location=${client.env.home}/software/maven
+eclipse.m2.runtimesNodes/maven/type=EXTERNAL
+eclipse.m2.defaultRuntime=maven


### PR DESCRIPTION
Issue Discription :  

Maven install fails in eclipse for OASP4J and other distributions . It has been found that eclipse by default uses its m2e embedded version 3.3.3 for build process , which doesn't support for the build process to get successful result. 

This has been resolved by adding external maven to eclipse by default , with version 3.3.9 for successful build , so the respective changes has been done in preference file .

To check the m2e version in eclipse go to .
window -> preferences -> maven -> installations

Thank you.
