### PR TITLE
Add cygwin console script

### DIFF
--- a/oasp4j-ide-scripts/src/main/resources/console-cygwin.bat
+++ b/oasp4j-ide-scripts/src/main/resources/console-cygwin.bat
@@ -1,0 +1,11 @@
+@echo off
+
+pushd %~dp0
+
+rem sets the required environment variables like JAVA_HOME, M2_REPO...
+call scripts\environment-project.bat
+
+popd
+
+#start C:\cygwin64\bin\mintty.exe -i /Cygwin-Terminal.ico -
+start C:\cygwin64\bin\mintty.exe -i /Cygwin-Terminal.ico /bin/env CHERE_INVOKING=1 TERMINAL_TITLE=[PNR] /bin/bash -l


### PR DESCRIPTION
Each developer has his favorite tool to use. So we should provide some more console scripts, which enable initialization of the ide variables. This is for cygwin.