### PR TITLE
Add git-bash console script

### DIFF
--- a/oasp4j-ide-scripts/src/main/resources/console-git-bash.bat
+++ b/oasp4j-ide-scripts/src/main/resources/console-git-bash.bat
@@ -1,0 +1,10 @@
+@echo off
+
+pushd %~dp0
+
+rem sets the required environment variables like JAVA_HOME, M2_REPO...
+call scripts\environment-project.bat
+
+popd
+
+start "" "%SYSTEMDRIVE%\Program Files\Git\git-bash.exe"

--- a/oasp4j-ide-scripts/src/main/resources/console-git-bash.bat
+++ b/oasp4j-ide-scripts/src/main/resources/console-git-bash.bat
@@ -7,4 +7,10 @@ call scripts\environment-project.bat
 
 popd
 
-start "" "%SYSTEMDRIVE%\Program Files\Git\git-bash.exe"
+if EXIST "%SYSTEMDRIVE%\Program Files\Git\bin\sh.exe". (
+	"%SYSTEMDRIVE%\Program Files\Git\bin\sh.exe" --login
+) else (
+	if EXIST "%SYSTEMDRIVE%\Program Files (x86)\Git\bin\sh.exe". (
+		"%SYSTEMDRIVE%\Program Files (x86)\Git\bin\sh.exe" --login
+	)
+)


### PR DESCRIPTION
Each developer has his favorite tool to use. So we should provide some more console scripts, which enable initialization of the ide variables. This is for git-bash.