### PR TITLE
Fixed the error of the repository geronimo

### DIFF
--- a/docs/oomph/products/OomphDev.setup
+++ b/docs/oomph/products/OomphDev.setup
@@ -216,7 +216,7 @@
     <repository
         url="http://update.eclemma.org/"/>
     <repository
-        url="http://www.apache.org/dist/geronimo/eclipse/updates/"/>
+        url="http://archive.apache.org/dist/geronimo/eclipse/updates/"/>
     <repository
         url="http://www.nodeclipse.org/updates/"/>
     <repository


### PR DESCRIPTION
Changed the repository in the path oasp4j-ide\docs\oomph\products to the updated url to http://archive.apache.org/dist/geronimo/eclipse/updates/ to fix the error received in the oomph installer.